### PR TITLE
Continue moving configuration to pyproject, fix pytest pythonpath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ omit =[
 ]
 concurrency = ["multiprocessing"]
 parallel = true
+source = ["src/whoosh"]
 
 [tool.coverage.report]
 # Regexes for lines to exclude from consideration
@@ -187,3 +188,14 @@ max-args = 22  # Default is 5
 max-branches = 79  # Default is 12
 max-returns = 16  # Default is 6
 max-statements = 256  # Default is 50
+
+[tool.pytest.ini_options]
+# --tb= traceback print mode (long/short/line/native/no)
+addopts = "-rs --tb=short"
+
+norecursedirs = ".hg .tox _build tmp* env* benchmark stress"
+minversion = "3.0"
+python_files = "test_*.py"
+
+# addopts = "--cov --cov-report=lcov:lcov.info --cov-report=term"
+pythonpath = ["src"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,17 +14,3 @@ formats = zip,gztar
 [aliases]
 push = sdist bdist_wheel twine upload
 pushdocs = build_sphinx upload_sphinx
-
-[tool:pytest]
-; --tb= traceback print mode (long/short/line/native/no)
-addopts = -rs --tb=short
-
-norecursedirs = .hg .tox _build tmp* env* benchmark stress
-minversion = 3.0
-python_files = test_*.py
-
-[tool.coverage.run]
-source = ["src/whoosh"]
-
-[tool.pytest.ini_options]
-addopts = "--cov --cov-report=lcov:lcov.info --cov-report=term"


### PR DESCRIPTION
# Description

Continuing the move to `pyproject.toml` over `setup.cfg`, I've moved the `pytest` and `coverage` configuration in. In addition, I've configured `pythonpath` for `pytest`, so now a plain `python -m pytest` works.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
