### PR TITLE
fix charset.accent_maps type annotation

### DIFF
--- a/src/whoosh/support/charset.py
+++ b/src/whoosh/support/charset.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 #
 # http://github.com/aristus/accent-folding/blob/master/accent_fold.py
 
-accent_map = {
+str_accent_map: dict[str, str] = {
     "H": "h",  # H -> h
     "I": "i",  # I -> i
     "J": "j",  # J -> j
@@ -728,7 +728,7 @@ accent_map = {
 
 # The unicode.translate() method actually requires a dictionary mapping
 # character *numbers* to characters, for some reason.
-accent_map = {ord(k): v for k, v in accent_map.items()}
+accent_map: dict[int, str] = {ord(k): v for k, v in str_accent_map.items()}
 
 
 # This Sphinx charset table taken from http://speeple.com/unicode-maps.txt


### PR DESCRIPTION
# Description

`accent_maps` was initially a `dict[str, str]` and then converted to a `dict[int, str]` which confused `mypy`. Use a separate `str_accent_maps` temporary variable to avoid the issue.

# Checklist:

- [x ] I have performed a self-review of my own code
- [x ] I have commented my code in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
